### PR TITLE
Add Morse Chat server implementation in Rust

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1336,6 +1336,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
+name = "uuid"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc5cf98d8186244414c848017f0e2676b3fcb46807f6668a97dfe67359a3c4b7"
+dependencies = [
+ "getrandom",
+ "serde",
+]
+
+[[package]]
 name = "version_check"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,6 +1427,7 @@ version = "0.1.0"
 dependencies = [
  "rocket",
  "serde",
+ "uuid",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,3 +8,4 @@ edition = "2021"
 [dependencies]
 rocket = { version = "0.5.0-rc.1", features = ["json"] }
 serde = "*"
+uuid = { version = "0.8", features = ["serde", "v4"] }

--- a/src/controllers/message_controller.rs
+++ b/src/controllers/message_controller.rs
@@ -1,0 +1,61 @@
+use std::sync::{Mutex, Arc};
+
+use rocket::{serde::json::Json, http::Status, post, State, get, debug};
+
+use crate::{models::{message::Message, user::User}, services::message_service::{MessageService}, repository::user_repository::UserRepository};
+
+#[post("/messages", format = "application/json", data = "<message>")]
+pub fn send_message(
+    message: Json<Message>,
+    message_service_lock: &State<Arc<Mutex<MessageService>>>,
+    user_service_lock: &State<Arc<Mutex<UserRepository>>>
+) -> (Status, Result<Json<Message>, ()>) {
+    let parsed_message = Json::into_inner(message);
+
+    println!("Muye la Rust");
+    println!("{:?}", parsed_message);
+
+    let mut message_service = message_service_lock.lock().expect("Cannot access MessageService");
+    let user_service = user_service_lock.lock().expect("Cannot access MessageService");
+
+    println!("{:?}", parsed_message);
+
+    
+    let current_user: User;
+    if let Some(user) = user_service.get_user(parsed_message.uid.clone()) {
+        current_user = user.clone();
+    } else {
+        return (Status::NotFound, Err(()))
+    }
+
+    drop(user_service);
+
+    message_service.send_message(
+        current_user,
+        parsed_message.clone()
+    );
+
+    (Status::Created, Ok(Json(parsed_message.clone())))
+}
+
+#[get("/messages/<uid>")]
+pub async fn get_messages(
+    uid: String,
+    message_service_lock: &State<Arc<Mutex<MessageService>>>,
+    user_service_lock: &State<Arc<Mutex<UserRepository>>>
+) -> (Status, Result<Json<Vec<Message>>, ()>) {
+
+    println!("Muye la Rust");
+    let mut message_service = message_service_lock.lock().expect("Cannot access MessageService");
+    let user_service = user_service_lock.lock().expect("Cannot access MessageService");
+    
+    match user_service.get_user(uid.clone()) {
+        Some(user) => {
+            match message_service.get_messages(user.id.clone()) {
+                Some(messages) => (Status::Ok, Ok(Json(messages))),
+                None => (Status::Ok, Ok(Json(vec![]))),
+            }
+        },
+        None => (Status::NotFound, Err(())),
+    }
+}

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -1,0 +1,2 @@
+pub mod message_controller;
+pub mod user_controller;

--- a/src/controllers/user_controller.rs
+++ b/src/controllers/user_controller.rs
@@ -1,0 +1,24 @@
+use std::sync::{Arc, Mutex};
+
+use rocket::{post, http::Status, serde::json::Json, State};
+use uuid::Uuid;
+
+use crate::{models::user::User, repository::user_repository::UserRepository};
+
+#[post("/users")]
+pub async fn create_user(
+    user_service_lock: &State<Arc<Mutex<UserRepository>>>
+) -> (Status, Result<Json<User>, ()>) {
+    let mut user_service = user_service_lock.lock().expect("Cannot access MessageService");
+
+    let uuid = Uuid::new_v4();
+
+    let user = user_service.new_user(User {
+        id: uuid.to_string()
+    });
+
+    match user {
+        Some(user) => (Status::Created, Ok(Json(user))),
+        None => (Status::InternalServerError, Err(())),
+    }
+}

--- a/src/loaders/catchers.rs
+++ b/src/loaders/catchers.rs
@@ -1,0 +1,19 @@
+use rocket::{catch, serde::json::serde_json::{json, value::Value}};
+
+#[catch(404)]
+pub fn not_found() -> Value {
+    json!({
+        "Status": "Not Found",
+        "Code": 404,
+        "Reason": "Requested user was not found."
+    })
+}
+
+#[catch(500)]
+pub fn internal_server_error() -> Value {
+    json!({
+        "Status": "Internal Server Error",
+        "Code": 500,
+        "Reason": "Internal Server Error."
+    })
+}

--- a/src/loaders/mod.rs
+++ b/src/loaders/mod.rs
@@ -1,0 +1,1 @@
+pub mod catchers;

--- a/src/models/message.rs
+++ b/src/models/message.rs
@@ -1,0 +1,9 @@
+use std::fmt::{Debug};
+
+use serde::{Deserialize, Serialize};
+
+#[derive(Deserialize, Serialize, Debug, Clone)]
+pub struct Message {
+    pub uid: String,
+    pub message: String,
+}

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,0 +1,2 @@
+pub mod message;
+pub mod user;

--- a/src/models/user.rs
+++ b/src/models/user.rs
@@ -1,0 +1,6 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Clone, Serialize, Deserialize)]
+pub struct User {
+    pub id: String
+}

--- a/src/repository/message_repository.rs
+++ b/src/repository/message_repository.rs
@@ -1,0 +1,38 @@
+use std::{sync::Mutex, collections::{HashMap, VecDeque}};
+
+use crate::models::{message::Message, user::User};
+
+pub struct MessageRepository{
+    database: Mutex<HashMap<String, VecDeque<Message>>>
+}
+
+impl MessageRepository {
+    pub fn new() -> Self { 
+        Self { 
+            database: Mutex::new(HashMap::<String, VecDeque<Message>>::new())
+        }
+    }
+
+    pub fn save_message(&mut self, user: User,  message: Message) -> Option<()> {
+        let mut db = self.database.lock().expect("Cannot access database");
+
+        db.entry(user.id).or_insert(VecDeque::new()).push_back(message);
+
+        Some(())
+    }
+
+    pub fn get_messages(&mut self, user: User) -> Option<Vec<Message>> {
+        let mut db = self.database.lock().expect("Cannot access database");
+        
+        db.get_mut(&user.id).map(|mq| {
+            if let Some(message) = mq.front() {
+                println!("{:?}", message);
+            }
+
+            let messages = mq.drain(..).collect::<Vec<Message>>();
+
+            println!("{:?}", messages);
+            messages
+        })
+    }
+}

--- a/src/repository/mod.rs
+++ b/src/repository/mod.rs
@@ -1,0 +1,2 @@
+pub mod message_repository;
+pub mod user_repository;

--- a/src/repository/user_repository.rs
+++ b/src/repository/user_repository.rs
@@ -1,0 +1,50 @@
+use std::{sync::Mutex, collections::HashMap};
+
+use crate::models::user::User;
+
+pub struct UserRepository {
+    database: Mutex<HashMap<String, User>>
+}
+    
+impl UserRepository {
+    pub fn new() -> Self {
+        Self { 
+            database: Mutex::new(HashMap::<String, User>::new())
+        }
+    }
+    
+    pub fn new_user(&mut self, user: User) -> Option<User> {
+        let mut db = self.database.lock().expect("Cannot access database");
+
+        let newUser = db.entry(user.id.clone()).or_insert(user);
+
+        Some(User {
+            id: newUser.id.clone(),
+        })
+    }
+
+    pub fn get_users(&mut self) -> Option<Vec<User>> {
+        let db = self.database.lock().expect("Cannot access database");
+
+        let mut users = Vec::new();
+        for key in db.keys() {
+            let user = match db.get(key) {
+                Some(user) => User{id: user.id.clone()},
+                None => panic!("Cannot find user for existing key"),
+            };
+
+            users.push(user);
+        }
+
+        Some(users)
+    }
+
+    pub fn get_user(&self, uid: String) -> Option<User> {
+        let db = self.database.lock().expect("Cannot access database");
+
+        match db.get(&uid) {
+            Some(user) => Some(User{id: user.id.clone()}),
+            None => None,
+        }   
+    }
+}

--- a/src/services/message_service.rs
+++ b/src/services/message_service.rs
@@ -1,0 +1,52 @@
+use std::sync::{Arc, Mutex};
+
+use crate::{models::{message::{Message}, user::User}, repository::{message_repository::MessageRepository, user_repository::UserRepository}};
+
+pub struct MessageService {
+    message_repository: Arc<Mutex<MessageRepository>>,
+    user_repository: Arc<Mutex<UserRepository>>
+}
+
+impl MessageService {
+    pub fn new(
+        message_repository: Arc<Mutex<MessageRepository>>,
+        user_repository: Arc<Mutex<UserRepository>>
+    ) -> Self { 
+        Self { 
+            message_repository,
+            user_repository
+        } 
+    }
+
+    pub fn send_message(&mut self, sender: User, message: Message) -> Result<(), ()> {
+        let mut user_repository = self.user_repository.lock().expect("Cannot get lock for user_repository");
+        let mut message_repository = self.message_repository.lock().expect("Cannot get lock for user_repository");
+
+        match user_repository.get_users() {
+            Some(users) => {
+                for user in users.iter() {
+                    if user.id == sender.id {
+                        continue;
+                    }
+                    
+                    message_repository.save_message(user.clone(), message.clone());
+                }
+                Ok(())
+            },
+            None => Ok(())
+        }
+    }
+
+    pub fn get_messages(&mut self, uid: String) -> Option<Vec<Message>> {
+        let mut message_repository = self.message_repository.lock().expect("Cannot get lock for user_repository");
+
+        let messages = match message_repository.get_messages(User { id: uid }) {
+            Some(messages) => Some(messages),
+            None => None,
+        };
+
+        println!("Valoare {:?}", messages);
+
+        messages
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,0 +1,1 @@
+pub mod message_service;


### PR DESCRIPTION
Uses Rocket.rs framework
Add services for User and Message management
Add in-memory repositories
Add controller to create users
Add controller to send a message to all users
Add controller to read your messages

Uses Arc and Mutex to share the same instances of Service and Repository
for all requests. (via the Rocket State mechanism)